### PR TITLE
Update Citrix _os.py for correct timezone detection

### DIFF
--- a/dissect/target/plugins/os/unix/bsd/citrix/_os.py
+++ b/dissect/target/plugins/os/unix/bsd/citrix/_os.py
@@ -12,7 +12,7 @@ from dissect.target.target import Target
 RE_CONFIG_IP = re.compile(r"-IPAddress (?P<ip>[^ ]+) ")
 RE_CONFIG_HOSTNAME = re.compile(r"set ns hostName (?P<hostname>[^\n]+)\n")
 RE_CONFIG_TIMEZONE = re.compile(
-    r'set ns param -timezone "GMT\+(?P<hours>[0-9]+):(?P<minutes>[0-9]+)-.*-(?P<zone_name>.+)"'
+    r'set ns param.* -timezone "GMT\+(?P<hours>[0-9]+):(?P<minutes>[0-9]+)-.*-(?P<zone_name>.+)"'
 )
 RE_CONFIG_USER = re.compile(r"bind system user (?P<user>[^ ]+) ")
 RE_LOADER_CONFIG_KERNEL_VERSION = re.compile(r'kernel="/(?P<version>.*)"')


### PR DESCRIPTION
Fix a crash when fetching the timezone of the netscaler when it has a configline like 'set ns param -cookieversion 1 -timezone "GMT+02:00-CEST-Europe/Amsterdam"'.

```
Traceback (most recent call last):
  File "/root/citrix-netscaler-triage/iocitrix.py", line 267, in <module>
    main()
  File "/root/citrix-netscaler-triage/iocitrix.py", line 263, in main
    check_targets(args.targets)
  File "/root/citrix-netscaler-triage/iocitrix.py", line 228, in check_targets
    print_target_info(target)
  File "/usr/local/lib/python3.9/dist-packages/dissect/target/tools/info.py", line 133, in print_target_info
    print(f"Timezone      : {target.timezone}")
  File "/usr/local/lib/python3.9/dist-packages/dissect/target/target.py", line 622, in __getattr__
    result = func.__get__(p)
  File "/usr/local/lib/python3.9/dist-packages/dissect/target/helpers/cache.py", line 228, in cache_wrapper
    return cache.call(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/dissect/target/helpers/cache.py", line 104, in call
    func_cache[key] = self.func(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/dissect/target/plugins/os/unix/locale.py", line 35, in timezone
    zoneinfo_path = str(zoneinfo.readlink()).split("/")
  File "/usr/local/lib/python3.9/dist-packages/dissect/target/helpers/fsutil.py", line 747, in readlink
    path = self._accessor.readlink(self)
  File "/usr/local/lib/python3.9/dist-packages/dissect/target/helpers/fsutil.py", line 528, in readlink
    raise e
OSError: 22
```
